### PR TITLE
Fix #6 (Sforzando in diacritic)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -295,7 +295,7 @@ export class Sorrygle{
         let current:AST.RestrictedNotation|undefined;
         let modifier:MIDIOptionModifier;
 
-        if(v.name === "." || v.name === "~" || v.name === "t") for(const w of v.value) switch(w?.type){
+        if(v.name === "." || v.name === "~" || v.name === "t" || v.name === "!") for(const w of v.value) switch(w?.type){
           case "range":
             this.parseStackables(w.value, [ ...modifiers, (o, _, __, l) => {
               durations.set(l, getTickDuration(o.duration));


### PR DESCRIPTION
어떤 Diacritic 내부에 Sforzando가 들어가는 경우 Sforzando 안의 노트들의 길이가 없어지는 문제를 고쳤습니다.