### PR TITLE
Fix #6 (Sforzando in diacritic)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { AST } from "./AST";
 import grammar from "./grammar";
 import SemanticError from "./SemanticError";
 import { ControllerType, GlobalConfiguration, MIDIOptionModifier, TrackSet } from "./TrackSet";
-import { getTickDuration, toTick, transpose } from "./utils";
+import { getTickDuration, toTick, transpose, setSforzandoDurations } from "./utils";
 
 const MAX_GROUP_REFERENCES = 1000;
 const TICK_TO_MS = 60000 / 128;
@@ -295,7 +295,7 @@ export class Sorrygle{
         let current:AST.RestrictedNotation|undefined;
         let modifier:MIDIOptionModifier;
 
-        if(v.name === "." || v.name === "~" || v.name === "t" || v.name === "!") for(const w of v.value) switch(w?.type){
+        if(v.name === "." || v.name === "~" || v.name === "t") for(const w of v.value) switch(w?.type){
           case "range":
             this.parseStackables(w.value, [ ...modifiers, (o, _, __, l) => {
               durations.set(l, getTickDuration(o.duration));
@@ -304,7 +304,8 @@ export class Sorrygle{
             break;
           case "key": case "chord": case "diacritic":
             current = w;
-            durations.set(w.l, getTickDuration(target.quantization));
+            if(w.type === "diacritic" && w.name === "!") setSforzandoDurations(w, durations, target);
+            else durations.set(w.l, getTickDuration(target.quantization));
             innerList.push(w);
             break;
           case "rest":

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import MIDI = require("midi-writer-js");
+import { AST } from "./AST";
+import { TrackSet } from "./TrackSet";
 
 const REGEXP_PITCH = /^([A-G]#?)(\d+)$/;
 const NOTE_SEQUENCES = [
@@ -51,4 +53,10 @@ export function transpose(pitch:MIDI.Pitch|`x${number}/${number}`, amount:number
 }
 export function toTick(value:number):MIDI.Duration{
   return `T${value}` as any;
+}
+export function setSforzandoDurations(v:AST.Diacritic, durations:Map<number, number>, target:TrackSet){
+  for(const w of v.value) switch(w?.type){
+    case "key": case "chord": case "diacritic":
+      durations.set(w.l, getTickDuration(target.quantization));
+  }
 }


### PR DESCRIPTION
#7 에서는 착오가 있어 기존 이슈가 제대로 해결되지 않았고 다른 문제가 발생했습니다.
재작업하였고 아래 경우에 대해 의도대로 작동함을 확인했습니다.

### 1. Staccato 내부에 Sforzando
```
(q=2)<.vAvF<![vAC]_[vAF]_>>
```

### 2. Sforzando 내부에 Tie
```
(q=8) <![eb]~>vb<![eA]~>vF<![vbF]~>
```

### 기타
Sforzando 내부에 Tie가 있는 경우, Sforzando 내부에 Range가 있는 경우에도 잘 작동하는 것으로 보입니다.

### (#7 merge 이전과 비교했을 때) 변경점
![화면 캡처 2022-10-02 011448](https://user-images.githubusercontent.com/39524005/193418459-28e8eb30-55de-4cc6-8cb7-6875fc6b4d1f.png)
기존에는 `durations`에 Sforzando 내부 노트에 해당하는 l = 13, 19일 때의 노트 길이 값이 누락되어 문제가 발생했습니다.

![화면 캡처 2022-10-02 011608](https://user-images.githubusercontent.com/39524005/193418534-c797d48d-89a7-489f-bafd-a07e3d828c19.png)
`utils.ts`에 `setSforzandoDurations` 함수를 도입해 부모 Diacritic 내부의 Diacritic이 Sforzando일 경우 해당 Sforzando 내부 노트들의 길이 값을 `durations`에 반영할 수 있도록 수정했습니다.

Sorrygle의 코딩 컨벤션과 구조에 대해 완벽하게 이해하지 못했기 때문에 부족한 부분이 있다면 리뷰해주시면 감사하겠습니다.