### PR TITLE
Handle Arpeggio in Staccato.

### DIFF
--- a/src/AST.ts
+++ b/src/AST.ts
@@ -42,11 +42,7 @@ export namespace AST{
     'type': "group-declaration",
     'key': number,
     'value': Stackable[]
-  }|GroupReference|{
-    'l': number,
-    'type': "parallelization",
-    'values': Stackable[][]
-  }|{
+  }|GroupReference|Parallelization|{
     'l': number,
     'type': "emoji-reference",
     'key': string
@@ -96,7 +92,12 @@ export namespace AST{
     'name': "."|"~"|"!"|"t",
     'value': DiacriticComponent[]
   };
-  export type DiacriticComponent =  GroupReference|LocalConfiguration|Range|RestrictedNotation|Rest|null;
+  export type Parallelization = {
+    'l': number,
+    'type': "parallelization",
+    'values': Stackable[][]
+  };
+  export type DiacriticComponent =  GroupReference|LocalConfiguration|Range|RestrictedNotation|Rest|Parallelization|null;
   export type KeySet = {
     'l': number,
     'type': "key",
@@ -108,7 +109,7 @@ export namespace AST{
     'l': number,
     'type': "appoggiatura",
     'value': Array<KeySet|ChordSet|Range|null>
-  }
+  };
   export type ChordSet = {
     'l': number,
     'type': "chord",

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,6 +297,19 @@ export class Sorrygle{
         let modifier:MIDIOptionModifier;
 
         if(v.name === "." || v.name === "~" || v.name === "t") for(const w of v.value) switch(w?.type){
+          case "range":
+            this.parseStackables(w.value, [ ...modifiers, (o, _, __, l) => {
+              durations.set(l, getTickDuration(o.duration));
+            }], this.track.dummy);
+            innerList.push(w);
+            break;
+          case "diacritic":
+            // NOTE Diacritic should be treated like `range` since it has variable length.
+            this.parseDiacriticComponents(w.value, [ ...modifiers, (o, _, __, l) => {
+              durations.set(l, getTickDuration(o.duration));
+            }], this.track.dummy);
+            innerList.push(w);
+            break;
           case "chord": if(w.arpeggio){
             switch(v.name){
               case ".": R += this.parseStackables([{
@@ -322,22 +335,9 @@ export class Sorrygle{
                 // ??
               case "t":
                 // ??
-            }
-          } break;
-          case "range":
-            this.parseStackables(w.value, [ ...modifiers, (o, _, __, l) => {
-              durations.set(l, getTickDuration(o.duration));
-            }], this.track.dummy);
-            innerList.push(w);
-            break;
-          case "diacritic":
-            // NOTE Diacritic should be treated like `range` since it has variable length.
-            this.parseDiacriticComponents(w.value, [ ...modifiers, (o, _, __, l) => {
-              durations.set(l, getTickDuration(o.duration));
-            }], this.track.dummy);
-            innerList.push(w);
-            break;
-          case "key": case "chord":
+            } break;
+          }
+          case "key":
             current = w;
             durations.set(w.l, getTickDuration(target.quantization));
             innerList.push(w);

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,24 +313,26 @@ export class Sorrygle{
           case "chord": if(w.arpeggio){
             switch(v.name){
               case ".": R += this.parseStackables([{
-                l: w.l,
-                type: "parallelization",
-                values: w.value.map((g, i) => {
-                  const rest = i * ARPEGGIO_IN_STACCATO_INTERVAL;
-                  const length = STACCATO_LENGTH - rest;
-                  const R:AST.Stackable[] = [
-                    { l: g.l, type: "local-configuration", key: "q", value: toTick(length) },
-                    { l: g.l, type: "notation", value: g },
-                    { l: g.l, type: "local-configuration", key: "q", value: toTick(STACCATO_LENGTH) }
-                  ];
-                  if(rest) R.unshift(
-                    { l: g.l, type: "local-configuration", key: "q", value: toTick(rest) },
-                    { l: g.l, type: "rest" }
-                  );
-                  return R;
-                })
-              }], [ ...modifiers, o => o.arpeggio = true ], target);
-              break;
+                  l: w.l,
+                  type: "parallelization",
+                  values: w.value.map((g, i) => {
+                    const rest = i * ARPEGGIO_IN_STACCATO_INTERVAL;
+                    const length = STACCATO_LENGTH - rest;
+                    const R:AST.Stackable[] = [
+                      { l: g.l, type: "local-configuration", key: "q", value: toTick(length) },
+                      { l: g.l, type: "notation", value: g },
+                      { l: g.l, type: "local-configuration", key: "q", value: toTick(getTickDuration(target.quantization) - STACCATO_LENGTH) },
+                      { l: g.l, type: "rest" },
+                      { l: g.l, type: "local-configuration", key: "q", value: toTick(STACCATO_LENGTH) },
+                    ];
+                    if(rest) R.unshift(
+                      { l: g.l, type: "local-configuration", key: "q", value: toTick(rest) },
+                      { l: g.l, type: "rest" }
+                    );
+                    return R;
+                  })
+                }], [ ...modifiers, o => o.arpeggio = true ], target);
+                break;
               case "~":
                 // ??
               case "t":


### PR DESCRIPTION
Fixed `Parallelization length mismatch` error when Arpeggio is in Staccato.

Example: `<.[|ceg]>`

Because Grammar Preprocessor allows Arpeggio in Fermata or Trill too, we should think about whether implementation for those cases is needed or not.